### PR TITLE
Compile generated erlang during dictionary file compilation

### DIFF
--- a/src/clean_diameter.erl
+++ b/src/clean_diameter.erl
@@ -50,10 +50,11 @@ format_error(Reason) ->
 
 clean(State, _AppFile) ->
     AppDir = rebar_app_info:dir(_AppFile),
+    EbinDir = rebar_app_info:ebin_dir(_AppFile),
     DiaOpts = rebar_state:get(State, dia_opts, []),
     IncludeEbin = proplists:get_value(include, DiaOpts, []),
-    code:add_pathsz(["ebin" | IncludeEbin]),
-    GeneratedFiles = dia_generated_files(AppDir, "dia", "src", "include"),
+    code:add_pathsz([EbinDir | IncludeEbin]),
+    GeneratedFiles = dia_generated_files(AppDir, "dia", "src", "include", DiaOpts),
     ok = rebar_file_utils:delete_each(GeneratedFiles),
     ok.
 
@@ -61,9 +62,9 @@ clean(State, _AppFile) ->
 %% Internal functions
 %% ===================================================================
 
-dia_generated_files(AppDir, DiaDir, SrcDir, IncDir) ->
+dia_generated_files(AppDir, DiaDir, SrcDir, IncDir, DiaOpts) ->
     F = fun(File, Acc) ->
-            case catch diameter_dict_util:parse({path, File}, []) of
+            case catch diameter_dict_util:parse({path, File}, DiaOpts) of
                 {ok, Spec} ->
                     FileName = dia_filename(File, Spec),
                     [

--- a/src/rebar3_diameter_compiler.app.src
+++ b/src/rebar3_diameter_compiler.app.src
@@ -1,6 +1,6 @@
 {application, 'rebar3_diameter_compiler', [
     {description, "Compile diameter .dia files"},
-    {vsn, "0.3.1"},
+    {vsn, "0.4.0"},
     {registered, []},
     {applications, [
         kernel,


### PR DESCRIPTION
Some dictionaries depend on other dictionaries being processed. In order for the dependency to resolve, the generated erl file needs to be compiled and the diameter compiler needs to be pointed to compiled file. This change adds that compilation. In addition, it includes passing the dia_opts down to the dictionary processor. It works more like the original diameter compiler in rebar 2.