### PR TITLE
implement dictionary dependency resolution

### DIFF
--- a/src/compile_diameter.erl
+++ b/src/compile_diameter.erl
@@ -165,14 +165,11 @@ compile_order(DiaFiles, Opts) ->
 		     try
 			 {ok, Bin} = file:read_file(F),
 			 Inherits0 =
-			     [I || <<"@inherits ", I/binary>> <-
-				       binary:split(Bin, [<< $\n >>, << $\r >>],
-						    [global, trim])],
+			     binary:split(Bin, [<< $\n >>, << $\r >>], [global, trim_all]),
+			 Inherits1 =
+			     [binary:split(I, [<<" ">>, << $\t >>], [global, trim_all]) || I <- Inherits0],
 			 Inherits =
-			     lists:map(fun(X) ->
-					       [I|_] = binary:split(X, [<<" ">>]),
-					       I
-				       end, Inherits0),
+			     [I || [<<"@inherits">>, I | _] <- Inherits1],
 			 rebar_api:debug("Inherits for ~p: ~p~n", [Dict, Inherits]),
 			 add(Graph, {Dict, Inherits})
 		     catch

--- a/src/compile_diameter.erl
+++ b/src/compile_diameter.erl
@@ -58,15 +58,27 @@ compile(State, AppFile) ->
         CompileFirst ->
             [filename:join(DiaDir, filename:basename(F)) || F <- CompileFirst]
     end,
-    rebar_api:debug("Diameter first files: ~p~n", [DiaFirst]),
 
-    rebar_base_compiler:run({State, AppDir, EbinDir},
-                            DiaFirst,
-                            DiaDir,
-                            ".dia",
-                            SrcDir,
-                            ".erl",
-                            fun compile_dia/3).
+    DiaExtRe = "^(?!\\._).*\\.dia$",
+    Recursive = proplists:get_value(recursive, DiaOpts, true),
+
+    %% Find all possible source files
+    DiaFiles = rebar_utils:find_files(DiaDir, DiaExtRe, Recursive),
+    rebar_api:debug("Diameter files: ~p~n", [DiaFiles]),
+
+    case compile_order(DiaFiles, DiaOpts) of
+        {error, Reason} ->
+            rebar_api:error("DIAMETER error: ~p~n", [Reason]);
+	{ok, Order} ->
+	    rebar_api:debug("Diameter Order: ~p~n", [Order]),
+	    rebar_base_compiler:run({State, AppDir, EbinDir},
+				    DiaFirst ++ Order,
+				    DiaDir,
+				    ".dia",
+				    SrcDir,
+				    ".erl",
+				    fun compile_dia/3)
+    end.
 
 -spec format_error(any()) ->  iolist().
 format_error(Reason) ->
@@ -110,8 +122,22 @@ compile_dia(Source, Target, {State, AppDir, EbinDir}) ->
             _ = diameter_codegen:from_dict(FileName, Spec, IncludeOpts, hrl),
             ErlCOpts = [{outdir, EbinDir}] ++
                         rebar_state:get(State, erl_opts, []),
-            {Result, _} = compile:file(Target, ErlCOpts),
-            Result;
+	    case compile:file(Target, ErlCOpts) of
+		{ok, Module} ->
+		    case code:load_abs(EbinDir ++ "/" ++ atom_to_list(Module)) of
+			{error, LoadError} ->
+			    rebar_api:error(
+			      "Can't load DIAMTER dictionary ~p, error '~p'",
+			      [FileName, LoadError]);
+			{module, _} ->
+			    ok
+		    end;
+		Other ->
+		    rebar_api:error(
+		      "Can't compile DIAMTER dictionary ~p, error '~p'",
+		      [FileName, Other]),
+		    Other
+	    end;
         {error, Reason} ->
             rebar_api:error(
                 "Compiling ~s failed: ~s~n",
@@ -126,3 +152,86 @@ dia_filename(File, Spec) ->
         Name ->
             Name
     end.
+
+compile_order(DiaFiles, Opts) ->
+    Graph = digraph:new(),
+
+    DiaMods =
+	lists:foldl(fun(F, M) ->
+			  Dict = filename:rootname(filename:basename(F)),
+			  M#{Dict => F}
+		    end, #{}, DiaFiles),
+    maps:map(fun(Dict, F) ->
+		     try
+			 {ok, Bin} = file:read_file(F),
+			 Inherits0 =
+			     [I || <<"@inherits ", I/binary>> <-
+				       binary:split(Bin, [<< $\n >>, << $\r >>],
+						    [global, trim])],
+			 Inherits =
+			     lists:map(fun(X) ->
+					       [I|_] = binary:split(X, [<<" ">>]),
+					       I
+				       end, Inherits0),
+			 rebar_api:debug("Inherits for ~p: ~p~n", [Dict, Inherits]),
+			 add(Graph, {Dict, Inherits})
+		     catch
+			 _:_ -> ok
+		     end
+	     end, DiaMods),
+
+    Order =
+        case digraph_utils:topsort(Graph) of
+            false ->
+                case digraph_utils:is_acyclic(Graph) of
+                    true ->
+                        {error, no_sort};
+                    false ->
+                        Cycles = lists:sort(
+                                   [lists:sort(Comp) || Comp <- digraph_utils:strong_components(Graph),
+                                                        length(Comp)>1]),
+                        {error, {cycles, Cycles}}
+                end;
+            V ->
+		V1 = lists:foldl(fun(X, Acc) ->
+					 case maps:get(X, DiaMods, undefined) of
+					     undefined ->
+						 Acc;
+					     File ->
+						 [File | Acc]
+					 end
+				 end, [], V),
+                {ok, V1}
+        end,
+    true = digraph:delete(Graph),
+    Order.
+
+%% taken from rebar_digraph:
+%% @private Add a package and its dependencies to an existing digraph
+-spec add(digraph:graph(), {PkgName, [Dep]}) -> ok when
+      PkgName :: binary(),
+      Dep :: {Name, term()} | Name,
+      Name :: atom() | iodata().
+add(Graph, {PkgName, Deps}) ->
+    case digraph:vertex(Graph, PkgName) of
+        false ->
+            V = digraph:add_vertex(Graph, PkgName);
+        {V, []} ->
+            V
+    end,
+
+    lists:foreach(fun(Name1) ->
+			  Name = case Name1 of
+				     N when is_atom(N)      -> atom_to_list(Name1);
+				     {N, _} when is_list(N) -> N;
+				     N when is_list(N)      -> N;
+				     N when is_binary(N)    -> binary_to_list(N)
+			      end,
+                          V3 = case digraph:vertex(Graph, Name) of
+                                   false ->
+                                       digraph:add_vertex(Graph, Name);
+                                   {V2, []} ->
+                                       V2
+                               end,
+                          digraph:add_edge(Graph, V, V3)
+                  end, Deps).


### PR DESCRIPTION
Declaring the compile order manually does not work because
rebar3 is reordering the content of the dia_first_file config
directive.

This implements automatic dependency detect for DIAMETER dictionaries
by extracting the `@inherits` statements. Dictionaries are then
compiled and **loaded** in the right order.

A example of a complex DIAMETER dictionary inherits relation can be found at https://github.com/travelping/ergw_aaa/tree/feature/pcc-rules/dia